### PR TITLE
Fixed pint field type

### DIFF
--- a/search/solr/Configuring-Solr-for-use-with-Sitecore-8/index.md
+++ b/search/solr/Configuring-Solr-for-use-with-Sitecore-8/index.md
@@ -16,7 +16,7 @@ category: search
 
 **Step 3.** Do steps, described in workaround of article [https://kb.sitecore.net/articles/227897](https://kb.sitecore.net/articles/227897) for "schema.xml" in newly created folder.
     **Note:** for SOLR 5.X "pint" fildType definition should look like following one:
-`<fieldType name="pint" class="solr.**Trie**IntField"/>`
+     <pre>&lt;fieldType name="pint" class="solr.<b>Trie</b>IntField"/&gt;</pre>
 
 **Step 4.** Fix following lines in the file "schema.xml" (that were added to "schema.xml" by schema generator):
 


### PR DESCRIPTION
Removed *\* from TrieIntField type as some people simply did copy/paste of this type which broke Solr schema.
